### PR TITLE
Use stable gandi API url

### DIFF
--- a/bin/authenticate.sh
+++ b/bin/authenticate.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-api='https://dns.beta.gandi.net/api/v5'
+api='https://dns.api.gandi.net/api/v5'
 
 domain=$(echo "$CERTBOT_DOMAIN" | sed -r 's/.+\.(.+\..+)/\1/')
 subdomain=$(echo "$CERTBOT_DOMAIN" | sed -r 's/(.+)\..+\..+/\1/')

--- a/bin/cleanup.sh
+++ b/bin/cleanup.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-api='https://dns.beta.gandi.net/api/v5'
+api='https://dns.api.gandi.net/api/v5'
 
 domain=$(echo "$CERTBOT_DOMAIN" | sed -r 's/.+\.(.+\..+)/\1/')
 subdomain=$(echo "$CERTBOT_DOMAIN" | sed -r 's/(.+)\..+\..+/\1/')


### PR DESCRIPTION
The gandi api has changed its url for a more stable
one. Although https://dns.beta.gandi.net will continue to 
work for the foreseable future, this commits updates the
url to new official one.